### PR TITLE
MailingFooter component

### DIFF
--- a/public/storage.html
+++ b/public/storage.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Ethercast SSO Hub</title>
+    <title>Ethercast Storage Hub</title>
     <script src="https://cdn.rawgit.com/zendesk/cross-storage/1.0.0/dist/hub.min.js"
             integrity="sha384-CZHogoIJY4N0uZBmE9EBPymtzS9m3kBfGd+ge65IzoEzMdO8IF1Qx077oWbluuLJ"
             crossorigin="anonymous"></script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import AppHeader from './components/AppHeader';
 import AppFooter from './components/AppFooter';
+import MailingFooter from './components/MailingFooter';
 import { connect } from 'react-redux';
 import Auth from './util/auth-util';
 import { Auth0UserProfile } from 'auth0-js';
@@ -72,9 +73,9 @@ export default withRouter(
                 </div>
               </div>
 
-              <div style={{ flexShrink: 0 }}>
-                <AppFooter/>
-              </div>
+              <MailingFooter/>
+
+              <AppFooter/>
             </div>
           </div>
         );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -54,9 +54,7 @@ export default withRouter(
         return (
           <div>
             <div style={{ display: 'flex', minHeight: '100vh', flexDirection: 'column' }}>
-              <div>
-                <AppHeader principal={principal} onLogOut={logout}/>
-              </div>
+              <AppHeader principal={principal} onLogOut={logout}/>
 
               <ScrollToTop/>
 

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -31,89 +31,91 @@ function NavLink({ to, ...props }: any) {
 
 export default function AppHeader({ principal, onLogOut }: { principal: Auth0UserProfile | null, onLogOut: () => void }) {
   return (
-    <Menu stackable>
-      <Container>
-        <StyledMenuItem
-          as={Link}
-          to="/"
-          header
-          style={{
-            display: 'inline-block',
-            fontFamily: 'Roboto Slab',
-            fontSize: '1.2em',
-            padding: '0.5em 1em',
-            textAlign: 'center'
-          }}>
-          <Image
-            size="mini"
-            src="/hero.png"
+    <div>
+      <Menu stackable>
+        <Container>
+          <StyledMenuItem
+            as={Link}
+            to="/"
+            header
             style={{
               display: 'inline-block',
-              margin: '0 0.5em 0 -0.5em',
-              verticalAlign: 'middle'
-            }}
-          />
-          <span style={{ position: 'relative', top: 4 }}>
-            Ethercast
-          </span>
-        </StyledMenuItem>
-        {
-          principal ? [
-            <NavLink key="sub-link" to="/subscriptions">My subscriptions</NavLink>
-            // <NavLink key="api-keys-link" to="/api-keys">My API keys</NavLink>
-          ] : null
-        }
-
-        <Menu.Menu position="right">
-          <Dropdown item text="Networks" style={{ justifyContent: 'center' }}>
-            <Dropdown.Menu>
-              {
-                _.map(
-                  NETWORKS,
-                  (info, name) => (
-                    <Dropdown.Item
-                      style={{ textAlign: 'center' }}
-                      key={name}
-                      as="a"
-                      text={name}
-                      disabled={!info.enabled}
-                      active={info === netInfo}
-                      href={`https://${name.toLowerCase()}.ethercast.io`}
-                    />
-                  )
-                )
-              }
-            </Dropdown.Menu>
-          </Dropdown>
-
+              fontFamily: 'Roboto Slab',
+              fontSize: '1.2em',
+              padding: '0.5em 1em',
+              textAlign: 'center'
+            }}>
+            <Image
+              size="mini"
+              src="/hero.png"
+              style={{
+                display: 'inline-block',
+                margin: '0 0.5em 0 -0.5em',
+                verticalAlign: 'middle'
+              }}
+            />
+            <span style={{ position: 'relative', top: 4 }}>
+              Ethercast
+            </span>
+          </StyledMenuItem>
           {
-            principal ? (
-              [
-                principal.picture ? (
-                  <StyledMenuItem key="img">
-                    <Image height={28} circular src={principal.picture}/>
-                  </StyledMenuItem>
-                ) : null,
-                principal.name ? (
-                  <StyledMenuItem key="name">
-                    Logged in as <strong style={{ marginLeft: 4 }}>{principal.name}</strong>
-                  </StyledMenuItem>
-                ) : null
-              ]
-            ) : null
+            principal ? [
+              <NavLink key="sub-link" to="/subscriptions">My subscriptions</NavLink>
+              // <NavLink key="api-keys-link" to="/api-keys">My API keys</NavLink>
+            ] : null
           }
 
-          <StyledMenuItem key="act">
+          <Menu.Menu position="right">
+            <Dropdown item text="Networks" style={{ justifyContent: 'center' }}>
+              <Dropdown.Menu>
+                {
+                  _.map(
+                    NETWORKS,
+                    (info, name) => (
+                      <Dropdown.Item
+                        style={{ textAlign: 'center' }}
+                        key={name}
+                        as="a"
+                        text={name}
+                        disabled={!info.enabled}
+                        active={info === netInfo}
+                        href={`https://${name.toLowerCase()}.ethercast.io`}
+                      />
+                    )
+                  )
+                }
+              </Dropdown.Menu>
+            </Dropdown>
+
             {
               principal ? (
-                <Button onClick={onLogOut}>Log out</Button>
-              ) : (
-                <Button primary onClick={Auth.login}>Log in</Button>
-              )
+                [
+                  principal.picture ? (
+                    <StyledMenuItem key="img">
+                      <Image height={28} circular src={principal.picture}/>
+                    </StyledMenuItem>
+                  ) : null,
+                  principal.name ? (
+                    <StyledMenuItem key="name">
+                      Logged in as <strong style={{ marginLeft: 4 }}>{principal.name}</strong>
+                    </StyledMenuItem>
+                  ) : null
+                ]
+              ) : null
             }
-          </StyledMenuItem>
-        </Menu.Menu>
-      </Container>
-    </Menu>
+
+            <StyledMenuItem key="act">
+              {
+                principal ? (
+                  <Button onClick={onLogOut}>Log out</Button>
+                ) : (
+                  <Button primary onClick={Auth.login}>Log in</Button>
+                )
+              }
+            </StyledMenuItem>
+          </Menu.Menu>
+        </Container>
+      </Menu>
+    </div>
   );
 }

--- a/src/components/MailingFooter.tsx
+++ b/src/components/MailingFooter.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Button, Container, Icon, Input, List, Segment } from 'semantic-ui-react';
+
+interface State {
+  email: string;
+  hide: boolean;
+};
+
+export default class MailingFooter extends React.Component<{}, State> {
+  state = { email: '', hide: false };
+
+  dismiss = () => {
+    this.setState({ hide: true });
+  };
+
+  updateEmail = (_: any, { value }: { value: string }) => {
+    this.setState({ email: value });
+  };
+
+  subscribe = () => {
+    // TODO
+    this.dismiss();
+  };
+
+  render() {
+    if (this.state.hide) {
+      return null;
+    }
+
+    return (
+      <Segment inverted vertical style={{ position: 'fixed', bottom: 0, width: '100%', zIndex: 1 }}>
+        <Button circular floated="right" icon="close" inverted style={{ marginRight: '1em' }} onClick={this.dismiss}/>
+        <Container textAlign="center">
+          <List horizontal inverted style={{ textAlign: 'center' }}>
+            <List.Item style={{ fontSize: '1.5rem', textAlign: 'left', verticalAlign: 'middle' }}>
+              <Icon name="announcement"/> We're in open beta!<br/>
+              Get an email when we've got news:
+            </List.Item>
+            <List.Item style={{ verticalAlign: 'middle' }}>
+              <Input action={{ content: 'Subscribe', onClick: this.subscribe }} inverted placeholder="email" onChange={this.updateEmail}/>
+            </List.Item>
+          </List>
+        </Container>
+      </Segment>
+    );
+  }
+}

--- a/src/components/MailingFooter.tsx
+++ b/src/components/MailingFooter.tsx
@@ -19,7 +19,11 @@ export default class MailingFooter extends React.Component<{}, State> {
 
   subscribe = () => {
     const url = `https://ethercast.us12.list-manage.com/subscribe?u=bcdba189ebc2ddf23f14ae273&id=ba729c94d7&MERGE0=${this.state.email}`;
-    window.open(url, '_blank', 'noopener');
+    const succeeded = window.open(url, '_blank', 'noopener');
+    if (!succeeded) {
+      // this browser does not support or is blocking the popup
+      window.location.href = url;
+    }
     this.dismiss();
   };
 

--- a/src/components/MailingFooter.tsx
+++ b/src/components/MailingFooter.tsx
@@ -18,7 +18,8 @@ export default class MailingFooter extends React.Component<{}, State> {
   };
 
   subscribe = () => {
-    // TODO
+    const url = `https://ethercast.us12.list-manage.com/subscribe?u=bcdba189ebc2ddf23f14ae273&id=ba729c94d7&MERGE0=${this.state.email}`;
+    window.open(url, '_blank', 'noopener');
     this.dismiss();
   };
 

--- a/src/components/MailingFooter.tsx
+++ b/src/components/MailingFooter.tsx
@@ -1,25 +1,20 @@
 import * as React from 'react';
-import { Button, Container, Icon, Input, List, Segment } from 'semantic-ui-react';
+import { Button, Container, Icon, List, Segment } from 'semantic-ui-react';
 
 interface State {
-  email: string;
   hide: boolean;
 };
 
 export default class MailingFooter extends React.Component<{}, State> {
-  state = { email: '', hide: false };
+  state = { hide: false };
 
   dismiss = () => {
     this.setState({ hide: true });
   };
 
-  updateEmail = (_: any, { value }: { value: string }) => {
-    this.setState({ email: value });
-  };
-
   subscribe = () => {
-    const url = `https://ethercast.us12.list-manage.com/subscribe?u=bcdba189ebc2ddf23f14ae273&id=ba729c94d7&MERGE0=${this.state.email}`;
-    const succeeded = window.open(url, '_blank', 'noopener');
+    const url = 'https://groups.google.com/a/ethercast.io/forum/?nomobile=true#!forum/updates/join';
+    const succeeded = window.open(url, 'noopener');
     if (!succeeded) {
       // this browser does not support or is blocking the popup
       window.location.href = url;
@@ -33,16 +28,15 @@ export default class MailingFooter extends React.Component<{}, State> {
     }
 
     return (
-      <Segment inverted vertical style={{ position: 'fixed', bottom: 0, width: '100%', zIndex: 1 }}>
+      <Segment inverted vertical style={{ position: 'fixed', bottom: 0, width: '100%', zIndex: 1, backgroundColor: '#2185d0' }}>
         <Button circular floated="right" icon="close" inverted style={{ marginRight: '1em' }} onClick={this.dismiss}/>
         <Container textAlign="center">
           <List horizontal inverted style={{ textAlign: 'center' }}>
             <List.Item style={{ fontSize: '1.5rem', textAlign: 'left', verticalAlign: 'middle' }}>
-              <Icon name="announcement"/> We're in open beta!<br/>
-              Get an email when we've got news:
+              <Icon name="announcement"/> We're in open beta! Get an email when we've got news:
             </List.Item>
             <List.Item style={{ verticalAlign: 'middle' }}>
-              <Input action={{ content: 'Subscribe', onClick: this.subscribe }} inverted placeholder="email" onChange={this.updateEmail}/>
+              <Button inverted content='Subscribe' onClick={this.subscribe}/>
             </List.Item>
           </List>
         </Container>

--- a/src/util/auth-util.tsx
+++ b/src/util/auth-util.tsx
@@ -1,8 +1,7 @@
 import * as auth0 from 'auth0-js';
 import { Auth0DecodedHash, Auth0UserProfile, AuthOptions } from 'auth0-js';
 import { Scope } from '../debt/ethercast-backend-model';
-import { CrossStorageClient } from 'cross-storage';
-import * as _ from 'underscore';
+import connectStorage from './connect-storage';
 
 const scope = Object.keys(Scope)
   .map(k => Scope[ k ])
@@ -21,18 +20,6 @@ const AUTH_SETTINGS: AuthOptions = {
 const auth = new auth0.WebAuth(AUTH_SETTINGS);
 
 const AUTH_RESULT = 'auth_result';
-
-const connectStorage = _.once(
-  async function () {
-    const storage = new CrossStorageClient(
-      process.env.NODE_ENV === 'production' ?
-        'https://ethercast.io/sso.html' :
-        '/sso.html'
-    );
-    await storage.onConnect();
-    return storage;
-  }
-);
 
 async function setSession(authResult: Auth0DecodedHash | null): Promise<void> {
   const storage = await connectStorage();

--- a/src/util/connect-storage.tsx
+++ b/src/util/connect-storage.tsx
@@ -1,0 +1,14 @@
+import { CrossStorageClient } from 'cross-storage';
+import * as _ from 'underscore';
+
+export default _.once(
+  async function () {
+    const storage = new CrossStorageClient(
+      process.env.NODE_ENV === 'production' ?
+        'https://ethercast.io/storage.html' :
+        '/storage.html'
+    );
+    await storage.onConnect();
+    return storage;
+  }
+);


### PR DESCRIPTION
Things that can be moved to a separate PR:
- Generalizes cross-domain storage
- Simplifies AppHeader/Footer markup

Things that cannot:
- Persist a sticky mailing list form on bottom of page until dismissed or signed up

<s>The form plugs the entered email into an actual mailchimp form for signup to a legitimate mailchimp list.</s>The form links to a signup for a google groups listserv.
With cross-domain storage, we *could* mark when a user has already signed up and stop bothering them, but I wanted to get **something** up tonight and I was mostly learning patterns.